### PR TITLE
added GUI map functionality

### DIFF
--- a/src/main/java/com/xebia/incubator/xebium/GuiMap.java
+++ b/src/main/java/com/xebia/incubator/xebium/GuiMap.java
@@ -1,0 +1,68 @@
+package com.xebia.incubator.xebium;
+
+import java.util.List;
+import java.util.Iterator;
+import java.util.HashMap;
+
+/**
+ * Create a GUI Map containing friendly names for locators (e.g. xpaths and ids)
+ * <p><code>
+ * | Table:Gui Map                |<br>
+ * | friendly name | //some/xpath |
+ * </code></p>
+ */
+public class GuiMap {
+	private static HashMap<String,String> locators = new HashMap<String,String>();
+	
+	/**
+	 * Get a locator from the GUI Map
+	 *
+	 * @param key a friendly name for a locator
+	 * @return a locator (e.g. an xpath or an id)
+	 */
+	public static String getLocator(final String key) {
+		String value = locators.get(key);
+		return (value != null) ? value : key;
+	}
+	
+	/**
+	 * Add the friendly names and corresponding locators to the GUI Map
+	 *
+	 * <p><code>
+	 * | Table:Gui Map |
+	 * </code></p>
+	 *
+	 */
+	public static List doTable(List<List<String>> table) {
+		for(Iterator<List<String>> tableIterator = table.iterator(); tableIterator.hasNext(); ) {
+			List<String> row = tableIterator.next();
+			if (row.size() >= 2) {
+				// the friendly name must be in the first column
+				String key = new String(row.get(0));				
+				// the locator must be in the second column
+				String value = new String(row.get(1));
+				
+				// add the row to the GUI Map
+				locators.put(key,value);				
+				
+				// make sure that the returned table doesn't result in errors in the testcase
+				row.set(0,"pass");
+				row.set(1, "pass");
+				
+				// anything from the third column is considered a comment
+				if (row.size() > 2) {
+					for(int i = 2; i < row.size(); i++) {
+						row.set(i, "ignore");
+					}
+				}
+			}
+			
+			// this row only has one column, must be a comment
+			else if (row.size() == 1) {
+				row.set(0, "ignore");
+			}
+		}
+		return table;
+	}
+	
+}

--- a/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
+++ b/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
@@ -224,7 +224,8 @@ public class SeleniumDriverFixture {
 	 * @param target
 	 * @return
 	 */
-	public boolean doOn(final String command, final String target) {
+	public boolean doOn(final String command, String target) {
+		target = GuiMap.getLocator(target);
 		LOG.info("Performing | " + command + " | " + target + " |");
 		return executeDoCommand(command, new String[] { target });
 	}
@@ -239,7 +240,8 @@ public class SeleniumDriverFixture {
 	 * @param value
 	 * @return
 	 */
-	public boolean doOnWith(final String command, final String target, final String value) {
+	public boolean doOnWith(final String command, String target, final String value) {
+		target = GuiMap.getLocator(target);
 		LOG.info("Performing | " + command + " | " + target + " | " + value + " |");
 		return executeDoCommand(command, new String[] { target, value });
 	}
@@ -266,7 +268,8 @@ public class SeleniumDriverFixture {
 	 * @param target
 	 * @return
 	 */
-	public String isOn(final String command, final String target) {
+	public String isOn(final String command, String target) {
+		target = GuiMap.getLocator(target);
 		LOG.info("Storing result from | " + command + " | " + target + " |");
 		return executeCommand(new ExtendedSeleniumCommand(command), new String[] { target }, stepDelay);
 	}


### PR DESCRIPTION
This commit allows users to assign a friendly name to a locator.
We wanted to separate the element locators (e.g. xpaths, ids and css selectors) from the Selenium commands to increase maintainability and reusability.
Furthermore, this can be used to hide long and complicated xpaths from the testers.

For example, this allows you to create a GUI map with:
`|Table:Gui Map                                |
|language|xpath=//select[@id="language"]/../..|
`

and then use it in your code with:
`|ensure|do|waitForElementPresent|on|language|
|ensure|do|click                               |on|language|`

This is completely backwards-compatible with projects without a defined GUI map.
