### PR TITLE
ondersteuning voor browser-specifieke instellingen

### DIFF
--- a/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
+++ b/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
@@ -14,6 +14,7 @@ import org.openqa.selenium.WebDriverCommandProcessor;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.firefox.PreferencesWrapper;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.slf4j.Logger;
@@ -42,6 +43,8 @@ public class SeleniumDriverFixture {
 
 	private LocatorCheck locatorCheck;
 	
+    private File customProfilePreferencesFile;
+
 	public SeleniumDriverFixture() {
 		LOG.info("Instantiating a fresh Selenium Driver Fixture");
 	}
@@ -52,11 +55,12 @@ public class SeleniumDriverFixture {
 		
 		if ("firefox".equalsIgnoreCase(browser)) {
 			FirefoxProfile profile = new FirefoxProfile();
-			// Ensure we deal with untrusted and unverified hosts.
-			File userPrefs = new File("firefox.properties");
-			if (userPrefs.exists()) {
-				profile.updateUserPrefs(userPrefs);
-			}
+
+            if (customProfilePreferencesFile != null) {
+                new PreferencesWrapper(customProfilePreferencesFile).addTo(profile);
+            }
+
+            // Ensure we deal with untrusted and unverified hosts.
 			profile.setAcceptUntrustedCertificates(true);
 			profile.setAssumeUntrustedCertificateIssuer(true);
 			// Allow Basic Authentication without confirmation
@@ -78,6 +82,9 @@ public class SeleniumDriverFixture {
 		return new WebDriverCommandProcessor(browserUrl, driver);
 	}
 
+    public void loadCustomBrowserPreferencesFromFile(String filename) {
+        this.customProfilePreferencesFile = new File(filename);
+    }
 	
 	/**
 	 * <p><code>

--- a/src/main/java/org/openqa/selenium/firefox/PreferencesWrapper.java
+++ b/src/main/java/org/openqa/selenium/firefox/PreferencesWrapper.java
@@ -1,0 +1,22 @@
+package org.openqa.selenium.firefox;
+
+import java.io.File;
+
+
+/**
+ * Wrapper class for Preferences.
+ * 
+ * This class serves as a workaround for generating Preferences objects outside Selenium's own packages, as the
+ * Preferences class itself is set to 'package-private'.
+ * 
+ */
+public class PreferencesWrapper extends Preferences {
+
+    /**
+     * @param file
+     *        a file containing Firefox preferences. The file is expected to contain .js style firefox preferences.
+     */
+    public PreferencesWrapper(File file) {
+        super(file);
+    }
+}


### PR DESCRIPTION
Met deze kleine patch wordt het mogelijk om extra browser instellingen te zetten via de SeleniumDriverFixture. Gebruikers kunnen met de 'load Custom Browser Preferences From File' instructie een eigen instellingenbestand meegeven. De inhoud van dit bestand heb ik browser specifiek gelaten, zoals Selenium dat ook doet. Voorlopig biedt het alleen support voor FireFox, maar het zou in principe ook kunnen werken voor de andere browsers. 
