### PR TITLE
Update selenium version to newest 2.23.1 as FF 13 and 14 will not work with 2.21.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,12 +29,12 @@
   </licenses>
 
   <properties>
-  	<selenium.version>2.21.0</selenium.version>
+  	<selenium.version>2.23.1</selenium.version>
   	<fitnesse.version>20111025</fitnesse.version>
     <fitlibrary.version>20091020</fitlibrary.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>
-    <slf4j.version>1.6.2</slf4j.version>
+    <slf4j.version>1.6.4</slf4j.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
Hello,

I updated the version of selenium as 2.21.0 will not work with newer versions of Firefox. I ran the example 001 to 007 successfully on my computer:

```
Apache Maven 3.0.4 (r1232337; 2012-01-17 09:44:56+0100)
Maven home: /usr/local/Cellar/maven/current/libexec
Java version: 1.6.0_31, vendor: Apple Inc.
Java home: /Library/Java/JavaVirtualMachines/1.6.0_31-b04-413.jdk/Contents/Home
Default locale: de_DE, platform encoding: MacRoman
OS name: "mac os x", version: "10.7.4", arch: "x86_64", family: "mac
```

I am on the Firefox beta channel, my browser: Firefox 14.0 on Mac OS X Lion.

I also updated slf4j to 1.6.4.

Regards
Mirko
