### PR TITLE
Put screenshots under the FitNesseRoot (even when the root was changed)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
       <groupId>org.fitnesse</groupId>
       <artifactId>fitnesse</artifactId>
       <version>${fitnesse.version}</version>
-      <scope>runtime</scope>
     </dependency>
     <!--
     <dependency>


### PR DESCRIPTION
When someone modifies the FitNesseRoot, screenshots still were stored at the
default location.

This patch makes the screenshot path relative to the FitNesseRoot, unless it
was set explicitly.
