### PR TITLE
Changed alias functionality.

### DIFF
--- a/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
+++ b/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
@@ -46,7 +46,9 @@ public class SeleniumDriverFixture {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SeleniumDriverFixture.class);
 
-	private static final String ALIAS_PREFIX = "%";
+	private static final String ALIAS_PREFIX = "%{";
+	
+	private static final String ALIAS_SUFFIX = "}";
 
 	private CommandProcessor commandProcessor;
 
@@ -382,12 +384,15 @@ public class SeleniumDriverFixture {
 
 	private String unalias(String value) {
 		String result = value;
-		if (value != null && value.startsWith(ALIAS_PREFIX)) {
-			String alias = value.substring(ALIAS_PREFIX.length());
-			String subst = aliases.get(alias);
-			if (subst != null) {
-			    LOG.info("Expanded alias '" + alias + "' to '" + result + "'");
-			    result = subst;
+		int beginAlias = 0; 
+		while (result != null && result.indexOf((ALIAS_PREFIX), beginAlias) != -1)  {
+			beginAlias = result.indexOf(ALIAS_PREFIX, beginAlias)+ALIAS_PREFIX.length();
+			int endAlias = result.indexOf(ALIAS_SUFFIX, beginAlias);
+			String alias = result.substring(beginAlias, endAlias);
+			String actual = aliases.get(alias);
+			if (actual != null) {
+				result = result.replace(ALIAS_PREFIX + alias + ALIAS_SUFFIX, actual);
+				LOG.info("Expanded alias '" + alias + "' to '" + actual + "'");
 			}
 		}
 		return result;

--- a/src/test/java/com/xebia/incubator/xebium/SeleniumDriverFixtureTest.java
+++ b/src/test/java/com/xebia/incubator/xebium/SeleniumDriverFixtureTest.java
@@ -62,22 +62,58 @@ public class SeleniumDriverFixtureTest {
 
         given(commandProcessor.doCommand(anyString(), isA(String[].class))).willReturn(expectedString);
         seleniumDriverFixture.addAliasForLocator(alias, expectedString);
-        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "%" + alias);
+        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "%{" + alias + "}");
         assertThat(result, is(true));
     }
 
     @Test
     public void shouldIgnoreMissingAlias() {
-        given(commandProcessor.doCommand(anyString(), isA(String[].class))).willReturn("%foo");
-        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "%foo");
+        given(commandProcessor.doCommand(anyString(), isA(String[].class))).willReturn("%{foo}");
+        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "%{foo}");
         assertThat(result, is(true));
     }
 
     @Test
     public void shouldIgnoreEmptyAlias() {
-        given(commandProcessor.doCommand(anyString(), isA(String[].class))).willReturn("%");
-        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "%");
+        given(commandProcessor.doCommand(anyString(), isA(String[].class))).willReturn("%{}");
+        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "%{}");
         assertThat(result, is(true));
     }
+    
+    @Test
+    public void shouldResolveAliasSurroundedByText() {
+        String expectedString = "Het laatste nieuws het eerst op nu.nl";
+        String alias = "laatsteNieuws";
+        String aliasValue = "laatste nieuws";
 
+        given(commandProcessor.doCommand(anyString(), isA(String[].class))).willReturn(expectedString);
+        seleniumDriverFixture.addAliasForLocator(alias, aliasValue);
+        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "Het %{" + alias + "} het eerst op nu.nl");
+        assertThat(result, is(true));
+    }
+    
+    @Test
+    public void shouldResolveMultipleAliases() {
+        String alias1 = "part1";
+        String expectedString1 = "Het laatste nieuws ";
+        String alias2 = "part2";
+        String expectedString2 = "het eerst op nu.nl";
+
+        given(commandProcessor.doCommand(anyString(), isA(String[].class))).willReturn(expectedString1 + expectedString2);
+        seleniumDriverFixture.addAliasForLocator(alias1, expectedString1);
+        seleniumDriverFixture.addAliasForLocator(alias2, expectedString2);
+        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "%{" + alias1 + "}%{" + alias2 + "}");
+        assertThat(result, is(true));
+    }
+    
+    @Test
+    public void shouldResolveOnlyKnownAlias() {
+        String alias1 = "part1";
+        String expectedString1 = "Het laatste nieuws ";
+        
+        given(commandProcessor.doCommand(anyString(), isA(String[].class))).willReturn(expectedString1 + "%{part2}");
+        seleniumDriverFixture.addAliasForLocator(alias1, expectedString1);
+        final boolean result = seleniumDriverFixture.doOnWith("verifyText", "//*[@id='masthead']/div/h1", "%{" + alias1 + "}%{part2}");
+        assertThat(result, is(true));
+    }
 }


### PR DESCRIPTION
Aliases should now start with
'%{' and end with '}'. This change makes it possible to combine aliases
with other aliases and/or text.
Also added tests for this functionality.

Related to #42
