### PR TITLE
Supports Selenium 2.45, TAB, BACKSPACE, Selenium Grid File Upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>xebium</artifactId>
   <groupId>com.xebia.incubator</groupId>
-  <version>0.13-SNAPSHOT</version>
+  <version>0.14-SNAPSHOT-mqm</version>
   <name>Xebium</name>
   <packaging>jar</packaging>
 
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <selenium.version>2.42.0</selenium.version>
+    <selenium.version>2.43.1</selenium.version>
     <fitnesse.version>20130530</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <selenium.version>2.45.0</selenium.version>
-    <fitnesse.version>20150114</fitnesse.version>
+    <fitnesse.version>20150424</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>
     <orgjson.version>20140107</orgjson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
                     <property name="sauce.accesskey" value="[provide accesskey through saucelabs.properties]" />
                     <java classname="fitnesseMain.FitNesseMain" classpathref="maven.runtime.classpath" fork="true">
                       <arg line="-p ${fitnesse.port}" />
-                      <arg line="-d ${fitnesse.dir}" />
+                      <arg line="-d ${user.dir}" />
                       <arg line="-e ${fitnesse.expiration}" />
                       <jvmarg value="-DBROWSER=firefox" />
                       <jvmarg value="-Dsauce.user=${sauce.user}" />
@@ -297,7 +297,7 @@
                     <java classname="fitnesseMain.FitNesseMain" classpathref="maven.runtime.classpath" fork="true" failonerror="true">
                       <arg line="-p 8001" />
                       <arg line="-c ProjectXebium?suite&amp;format=text&amp;excludeSuiteFilter=NotOnPhantomJS" />
-                      <arg line="-d ${fitnesse.dir}" />
+                      <arg line="-d ${user.dir}" />
                       <jvmarg value="-DBROWSER=phantomjs" />
                     </java>
                   </tasks>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <selenium.version>2.44.0</selenium.version>
+    <selenium.version>2.45.0</selenium.version>
     <fitnesse.version>20140901</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,11 @@
   </licenses>
 
   <properties>
-    <selenium.version>2.43.1</selenium.version>
-    <fitnesse.version>20130530</fitnesse.version>
+    <selenium.version>2.44.0</selenium.version>
+    <fitnesse.version>20140901</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>
+	<fitnesse.dir>.</fitnesse.dir>
     <maven-classpath-plugin.version>1.7</maven-classpath-plugin.version>
     <slf4j.version>1.6.4</slf4j.version>
     <operadriver.version>1.1</operadriver.version>
@@ -41,8 +42,8 @@
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/xebia/Xebium.git</connection>
-    <developerConnection>scm:git:git@github.com:xebia/Xebium.git</developerConnection>
+    <connection>scm:git:git://github.com/sglebs/Xebium.git</connection>
+    <developerConnection>scm:git:git@github.com:sglebs/Xebium.git</developerConnection>
     <url>scm:git:http://github.com/xebia/Xebium</url>
   </scm>
 
@@ -245,7 +246,7 @@
                     <property name="sauce.accesskey" value="[provide accesskey through saucelabs.properties]" />
                     <java classname="fitnesseMain.FitNesseMain" classpathref="maven.runtime.classpath" fork="true">
                       <arg line="-p ${fitnesse.port}" />
-                      <arg line="-d ." />
+                      <arg line="-d ${fitnesse.dir}" />
                       <arg line="-e ${fitnesse.expiration}" />
                       <jvmarg value="-DBROWSER=firefox" />
                       <jvmarg value="-Dsauce.user=${sauce.user}" />
@@ -291,7 +292,7 @@
                     <java classname="fitnesseMain.FitNesseMain" classpathref="maven.runtime.classpath" fork="true" failonerror="true">
                       <arg line="-p 8001" />
                       <arg line="-c ProjectXebium?suite&amp;format=text&amp;excludeSuiteFilter=NotOnPhantomJS" />
-                      <arg line="-d ." />
+                      <arg line="-d ${fitnesse.dir}" />
                       <jvmarg value="-DBROWSER=phantomjs" />
                     </java>
                   </tasks>

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
                     <property name="sauce.accesskey" value="[provide accesskey through saucelabs.properties]" />
                     <java classname="fitnesseMain.FitNesseMain" classpathref="maven.runtime.classpath" fork="true">
                       <arg line="-p ${fitnesse.port}" />
-                      <arg line="-d ${user.dir}" />
+                      <arg line="-d ." />
                       <arg line="-e ${fitnesse.expiration}" />
                       <jvmarg value="-DBROWSER=firefox" />
                       <jvmarg value="-Dsauce.user=${sauce.user}" />
@@ -297,7 +297,7 @@
                     <java classname="fitnesseMain.FitNesseMain" classpathref="maven.runtime.classpath" fork="true" failonerror="true">
                       <arg line="-p 8001" />
                       <arg line="-c ProjectXebium?suite&amp;format=text&amp;excludeSuiteFilter=NotOnPhantomJS" />
-                      <arg line="-d ${user.dir}" />
+                      <arg line="-d ." />
                       <jvmarg value="-DBROWSER=phantomjs" />
                     </java>
                   </tasks>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <selenium.version>2.44.0</selenium.version>
+    <selenium.version>2.43.1</selenium.version>
     <fitnesse.version>20140901</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <selenium.version>2.45</selenium.version>
+    <selenium.version>2.45.0</selenium.version>
     <fitnesse.version>20140901</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <fitnesse.expiration>0</fitnesse.expiration>
 	<fitnesse.dir>.</fitnesse.dir>
     <maven-classpath-plugin.version>1.7</maven-classpath-plugin.version>
-    <slf4j.version>1.6.4</slf4j.version>
+    <slf4j.version>1.6.6</slf4j.version>
     <operadriver.version>1.1</operadriver.version>
     <phantomjsdriver.version>1.0.3</phantomjsdriver.version>
     <commons-lang.version>2.6</commons-lang.version>
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0</version>
+      <version>18.0</version>
     </dependency>
 
     <!-- runtime dependencies -->
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.5</version>
+      <version>4.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -126,13 +126,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.8.5</version>
+      <version>1.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <version>1.1</version>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
 
@@ -247,7 +247,7 @@
                     <java classname="fitnesseMain.FitNesseMain" classpathref="maven.runtime.classpath" fork="true">
                       <arg line="-p ${fitnesse.port}" />
                       <arg line="-d ${fitnesse.dir}" />
-                      <arg line="-e ${fitnesse.expiration}" />
+                      <arg line="-e ${fitnesse.expiration}" />   
                       <jvmarg value="-DBROWSER=firefox" />
                       <jvmarg value="-Dsauce.user=${sauce.user}" />
                       <jvmarg value="-Dsauce.accesskey=${sauce.accesskey}" />

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>xebium</artifactId>
   <groupId>com.xebia.incubator</groupId>
-  <version>0.14-SNAPSHOT-mqm</version>
+  <version>0.15-SNAPSHOT-mqm</version>
   <name>Xebium</name>
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,15 +29,15 @@
   </licenses>
 
   <properties>
-    <selenium.version>2.45.0</selenium.version>
+    <selenium.version>2.44.0</selenium.version>
     <fitnesse.version>20140901</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>
-	<fitnesse.dir>.</fitnesse.dir>
+    <orgjson.version>20140107</orgjson.version>
     <maven-classpath-plugin.version>1.7</maven-classpath-plugin.version>
     <slf4j.version>1.6.6</slf4j.version>
     <operadriver.version>1.1</operadriver.version>
-    <phantomjsdriver.version>1.0.3</phantomjsdriver.version>
+    <phantomjsdriver.version>1.2.1</phantomjsdriver.version>
     <commons-lang.version>2.6</commons-lang.version>
   </properties>
 
@@ -79,7 +79,7 @@
       <version>${operadriver.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.detro.ghostdriver</groupId>
+      <groupId>com.codeborne</groupId>
       <artifactId>phantomjsdriver</artifactId>
       <version>${phantomjsdriver.version}</version>
     </dependency>
@@ -87,6 +87,11 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>${commons-lang.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>${orgjson.version}</version>
     </dependency>
     <!-- for some reason FitNesse appears to conflict with guava 15 from selenium -->
     <dependency>
@@ -247,7 +252,7 @@
                     <java classname="fitnesseMain.FitNesseMain" classpathref="maven.runtime.classpath" fork="true">
                       <arg line="-p ${fitnesse.port}" />
                       <arg line="-d ${fitnesse.dir}" />
-                      <arg line="-e ${fitnesse.expiration}" />   
+                      <arg line="-e ${fitnesse.expiration}" />
                       <jvmarg value="-DBROWSER=firefox" />
                       <jvmarg value="-Dsauce.user=${sauce.user}" />
                       <jvmarg value="-Dsauce.accesskey=${sauce.accesskey}" />
@@ -326,7 +331,7 @@
     <name>Xebia B.V.</name>
     <url>http://xebia.com</url>
   </organization>
-  
+
   <developers>
     <developer>
       <id>sgrijpink</id>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <selenium.version>2.43.1</selenium.version>
+    <selenium.version>2.45</selenium.version>
     <fitnesse.version>20140901</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.9.0</version>
+      <version>1.8.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <selenium.version>2.45.0</selenium.version>
-    <fitnesse.version>20140901</fitnesse.version>
+    <fitnesse.version>20150114</fitnesse.version>
     <fitnesse.port>8000</fitnesse.port>
     <fitnesse.expiration>0</fitnesse.expiration>
     <orgjson.version>20140107</orgjson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>14.0</version>
     </dependency>
 
     <!-- runtime dependencies -->

--- a/src/main/java/com/xebia/incubator/xebium/DefaultWebDriverSupplier.java
+++ b/src/main/java/com/xebia/incubator/xebium/DefaultWebDriverSupplier.java
@@ -126,6 +126,10 @@ public class DefaultWebDriverSupplier implements ConfigurableWebDriverSupplier {
 		this.browser = browser;
 	}
 
+    public String getBrowser() {
+        return this.browser;
+    }
+
 	public void setCustomProfilePreferencesFile(
 			File customProfilePreferencesFile) {
 		this.customProfilePreferencesFile = customProfilePreferencesFile;

--- a/src/main/java/com/xebia/incubator/xebium/RemoteWebDriverSupplier.java
+++ b/src/main/java/com/xebia/incubator/xebium/RemoteWebDriverSupplier.java
@@ -99,7 +99,9 @@ public class RemoteWebDriverSupplier implements Supplier<WebDriver> {
 	 * @throws RuntimeException in case of any error
 	 */
 	public WebDriver get() {
-		return new Augmenter().augment(new RemoteWebDriver(getRemote(), getCapabilities()));
+		RemoteWebDriver remoteWebDriver = new RemoteWebDriver(getRemote(), getCapabilities())   ;
+		remoteWebDriver.setFileDetector(new org.openqa.selenium.remote.LocalFileDetector()); // https://saucelabs.com/resources/selenium-file-upload
+		return new Augmenter().augment(remoteWebDriver);
 	}
 
 

--- a/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
+++ b/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
@@ -259,7 +259,8 @@ public class SeleniumDriverFixture {
 		executeCommand("setTimeout", new String[] { "" + this.timeout });
         WebDriver.Timeouts timeouts = getWebDriver().manage().timeouts();
         timeouts.setScriptTimeout(this.timeout, TimeUnit.MILLISECONDS);
-        timeouts.pageLoadTimeout(this.timeout, TimeUnit.MILLISECONDS);
+        if (!defaultWebDriverSupplier.getBrowser().toLowerCase().equals("safari"))  //mqm fix for #137 - safari does not support this API
+            timeouts.pageLoadTimeout(this.timeout, TimeUnit.MILLISECONDS);
 	}
 
 	/**

--- a/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
+++ b/src/main/java/com/xebia/incubator/xebium/SeleniumDriverFixture.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.xebia.incubator.xebium.FitNesseUtil.*;
 import static org.apache.commons.lang.StringUtils.join;
-
+import org.openqa.selenium.Keys;
 /**
  * Main fixture. Starts a browser session and execute commands.
  */
@@ -81,7 +81,15 @@ public class SeleniumDriverFixture {
 
 	public SeleniumDriverFixture() {
 		super();
+        initSpecialKeysMapping();
 	}
+
+    private void initSpecialKeysMapping() {
+        aliases.put("$KEY_BACKSPACE", Keys.chord(Keys.BACK_SPACE));
+        aliases.put("$KEY_TAB", Keys.chord(Keys.TAB));
+        aliases.put("$KEY_ENTER", Keys.chord(Keys.ENTER));
+        aliases.put("$KEY_RETURN", Keys.chord(Keys.RETURN));
+    }
 
     private WebDriver defaultWebDriverInstance() {
       return defaultWebDriverSupplier.newWebDriver();

--- a/src/main/java/com/xebia/incubator/xebium/fastseleniumemulation/Type.java
+++ b/src/main/java/com/xebia/incubator/xebium/fastseleniumemulation/Type.java
@@ -23,6 +23,7 @@ public class Type extends SeleneseCommand<Void> {
 		if (value == null) {
 			value = "";
 		}
+        value = value.replace("\\08", Keys.TAB); // sglebs fix
 		value = value.replace("\\10", Keys.ENTER);
 		value = value.replace("\\13", Keys.RETURN);
 		value = value.replace("\\27", Keys.ESCAPE);

--- a/src/main/java/com/xebia/incubator/xebium/fastseleniumemulation/Type.java
+++ b/src/main/java/com/xebia/incubator/xebium/fastseleniumemulation/Type.java
@@ -23,7 +23,8 @@ public class Type extends SeleneseCommand<Void> {
 		if (value == null) {
 			value = "";
 		}
-        value = value.replace("\\08", Keys.TAB); // sglebs fix
+        value = value.replace("\\08", Keys.BACK_SPACE); // sglebs fix
+        value = value.replace("\\09", Keys.TAB); // sglebs fix
 		value = value.replace("\\10", Keys.ENTER);
 		value = value.replace("\\13", Keys.RETURN);
 		value = value.replace("\\27", Keys.ESCAPE);


### PR DESCRIPTION
- supports TAB and BACKSPACE
- fix for Safari (timing)
- fix for file uploads with Selenium Grid
- FitNesse 20150424
- Selenium 2.45 (needed for recent versions of Firefox)
- had to upgrade some components due to Selenium 2.45

Feel free to retain the original FitNesse (I had issues with Guava too) but Selenium 2.45 support is a must for the latest Firefox. TAB and BACKSPACE support is also a must. The Selenium Grid file upload support is also a must if using the grid with tests that upload files to web forms.
